### PR TITLE
fix missing webshopId

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,5 +1,11 @@
 # Release Notes für Lastschrift
 
+## 1.0.1 (2019-05-08)
+
+### Gefixt
+
+- Ein eventuell auftretendes Problem beim Speichern zusätzlichen Mandanten im Assistenten wurde behoben.
+
 ## 1.0.0 (2019-03-27)
 
 ### Funktionen

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,8 +1,14 @@
 # Release Notes for Debit
 
+## 1.0.1 (2019-05-08)
+
+### Fixed
+
+- A possible problem with saving additional clients in the assistan has been fixed.
+
 ## 1.0.0 (2019-03-27)
 
-### Funktionen
+### Features
 
 - Payment method **Debit** for plentymarkets online stores
 - Entering the direct debit bank data when placing the order

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "version"           : "1.0.0",
+  "version"           : "1.0.1",
   "name"              : "Debit",
   "marketplaceName"   : {"de":"Lastschrift","en":"Debit"},
   "license"           : "AGPL-3.0",

--- a/src/Assistants/DebitAssistant.php
+++ b/src/Assistants/DebitAssistant.php
@@ -104,7 +104,7 @@ class DebitAssistant extends WizardProvider
                             "form" => [
                                 "allowDebitForGuest" => [
                                     'type' => 'checkbox',
-                                    'defaultValue' => 'false',
+                                    'defaultValue' => false,
                                     'options' => [
                                         'name' => 'debitAssistant.assistantDebitForGuestCheckbox'
                                     ]
@@ -123,7 +123,6 @@ class DebitAssistant extends WizardProvider
                             "form" => [
                                 "info_page_toggle" => [
                                     'type' => 'toggle',
-                                    'defaultValue' => false,
                                     'options' => [
                                         'name' => '',
                                     ]

--- a/src/Assistants/SettingsHandlers/DebitAssistantSettingsHandler.php
+++ b/src/Assistants/SettingsHandlers/DebitAssistantSettingsHandler.php
@@ -32,7 +32,12 @@ class DebitAssistantSettingsHandler implements WizardSettingsHandler
     public function handle(array $parameter)
     {
         $data = $parameter['data'];
-        $webstoreId = $parameter['optionId'];
+
+        if (!$this->isValidUUIDv4($parameter['optionId'])) {
+            $webstoreId = $parameter['optionId'];
+        } else {
+            $webstoreId = $data['config_name'];
+        }
 
         $this->saveDebitSettings($webstoreId, $data);
         $this->saveDebitShippingCountrySettings($webstoreId, $data);
@@ -205,5 +210,17 @@ class DebitAssistantSettingsHandler implements WizardSettingsHandler
         }
 
         return $this->debitPlugin;
+    }
+
+    /**
+     * Check if a string is a valid UUID.
+     *
+     * @param string $string
+     * @return false|int
+     */
+    public static function isValidUUIDv4($string)
+    {
+        $regex = '/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i';
+        return preg_match($regex, $string);
     }
 }


### PR DESCRIPTION
@plentymarkets/team-order-payment 

Bei dem Assistenten wurde beim Anlegen neuer Konfigurationen nicht mehr die korrekte `webstoreId` verwendet, sondern die UUID.